### PR TITLE
Tech: Preconcurrency attributed has been removed from Package.swift

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -1,5 +1,5 @@
 // swift-tools-version: 5.9
-@preconcurrency import PackageDescription
+import PackageDescription
 
 let package = Package(
 	name: "Package",


### PR DESCRIPTION
Удален атрибут preconcurrency из импорта PackageDescription